### PR TITLE
Add support for comment lines

### DIFF
--- a/lib/envy.ex
+++ b/lib/envy.ex
@@ -52,6 +52,7 @@ defmodule Envy do
     content
     |> String.split("\n")
     |> Enum.reject(&blank_entry?/1)
+    |> Enum.reject(&comment_entry?/1)
     |> Enum.map(&parse_line/1)
   end
 
@@ -87,5 +88,9 @@ defmodule Envy do
 
   defp blank_entry?(string) do
     string == ""
+  end
+
+  defp comment_entry?(string) do
+    String.match?(string, ~r(^\s*#))
   end
 end

--- a/test/envy_test.exs
+++ b/test/envy_test.exs
@@ -16,6 +16,10 @@ defmodule EnvyTest do
     cleanup_env(["FOO"])
   end
 
+  test "parse can ignore lines containing only comments" do
+    assert Envy.parse(~s(# comment))
+  end
+
   test "parse handle escaped quotes" do
     Envy.parse(~S(foo="\"awesome\""))
 


### PR DESCRIPTION
This adds support for comments in env files.

eg:

```
# Awesome!
foo=bar
```

This should be a fix for #1.