### PR TITLE
Add parentheses to avoid ambiguity

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,8 @@ defmodule Envy.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     package: package]
+     deps: deps(),
+     package: package()]
   end
 
   def application do


### PR DESCRIPTION
Fix warning messages on 1.4.