### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/envy.ex
+++ b/lib/envy.ex
@@ -71,7 +71,7 @@ defmodule Envy do
 
   defp parse_line(line) do
     [key, value] = line
-      |> String.strip
+      |> String.trim
       |> String.split(@key_value_delimeter, parts: 2)
 
     [key, parse_value(value)]


### PR DESCRIPTION
`String.strip/1` was deprecated in favor of `String.trim/1` in Elixir
1.5.

https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/Deprecations.md#table-of-deprecations