### PR TITLE
Preserve existing ENV variables if they exist

### DIFF
--- a/lib/envy.ex
+++ b/lib/envy.ex
@@ -29,7 +29,7 @@ defmodule Envy do
     Application.ensure_started(:mix)
     current_env = Mix.env |> to_string |> String.downcase
 
-    [".env", ".env.#{current_env}"] |> load
+    [".env.#{current_env}", ".env"] |> load
   end
 
   @doc """
@@ -95,7 +95,10 @@ defmodule Envy do
 
   defp load_env(pairs) when is_list(pairs) do
     Enum.each(pairs, fn([key, value]) ->
-      System.put_env(String.upcase(key), value)
+      key = String.upcase(key)
+      if System.get_env(key) == nil do
+        System.put_env(key, value)
+      end
     end)
   end
 

--- a/test/envy_test.exs
+++ b/test/envy_test.exs
@@ -6,6 +6,16 @@ defmodule EnvyTest do
 
     assert System.get_env("FOO") == "bar"
     assert System.get_env("BAR") == "foo"
+    cleanup_env(["FOO", "BAR"])
+  end
+
+  test "existing environment variables are preserved and take priority over dotenv config" do
+    System.put_env("BAZ", "already exists")
+    Envy.parse("foo=foo\nbar=bar\nbaz=baz")
+    assert System.get_env("FOO") == "foo"
+    assert System.get_env("BAR") == "bar"
+    assert System.get_env("BAZ") == "already exists"
+    cleanup_env(["FOO", "BAR", "BAZ"])
   end
 
   test "parse can handle quotes with comments" do


### PR DESCRIPTION
## Overview

This PR ensures that existing environment variables take priority over those inside the `.env` file, this allows us to override the `.env` file values with command line values, e.g.
```
FOO=bar mix phx.server
```
... and the command line `FOO=bar` will take priority over any instance of `FOO` in the `.env` file

## Priority

Note that because of this change in behavior I also needed to swap around the priority of the `.env.#{current_env}` file in order to ensure that version continues to take priority over the more generic `.env` variation (to maintain the existing behavior). The new order loads the env specific version **first** and now if a variable is set by that variant it takes priority over the generic `.env`. E.g the priority order is now:

 1. any existing environment variables
 2. any environment variables specified in the `.env.#{current_env}` variant (if it exists)
 3. any environment variables specified in the `.env` variant.

## Tests

I added a new unit test to confirm this behavior. All existing tests still pass.
