### PR TITLE
Add support for umbrella projects

### DIFF
--- a/lib/envy.ex
+++ b/lib/envy.ex
@@ -51,7 +51,9 @@ defmodule Envy do
   access to dependencies.
   """
   def reload_config do
-    Mix.Config.read!("config/config.exs") |> Mix.Config.persist
+    Mix.Project.config()[:config_path]
+    |> Mix.Config.read!()
+    |> Mix.Config.persist
   end
 
   @doc """

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
-%{"earmark": {:hex, :earmark, "0.1.19", "ffec54f520a11b711532c23d8a52b75a74c09697062d10613fa2dbdf8a9db36e", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.10.0", "f49c237250b829df986486b38f043e6f8e19d19b41101987f7214543f75947ec", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}
+%{
+  "earmark": {:hex, :earmark, "0.1.19", "ffec54f520a11b711532c23d8a52b75a74c09697062d10613fa2dbdf8a9db36e", [:mix], [], "hexpm", "db85f989ba3030d40d3a901d7eebbf926ee07355bf6113d730b8aaf9404a6bd7"},
+  "ex_doc": {:hex, :ex_doc, "0.10.0", "f49c237250b829df986486b38f043e6f8e19d19b41101987f7214543f75947ec", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm", "3d9f15777aa3fb62700d5984eb09ceeb6c1574d61be0f70801e3390e36942b35"},
+}


### PR DESCRIPTION
## Motivation

When working with an umbrella project and performing `Envy.reload_config/0` we got an exception because umbrella projects define their configuration at the root path instead of hardcoded `config/config.exs`.

## Proposed Solution

Relies on `Mix.Project.config/0` to fetch project metadata and access `:config_path`. This key is always present even if it is not defined in `mix.exs`, so it will work on both Elixir applications (umbrella or standalone).

## Additional details

- After running `mix deps.get`, `mix.lock` was updated automatically.
- Could you suggest an approach to write a unit test for `Envy.reload_config/0`?